### PR TITLE
WIP esm refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "jquery"
   ],
   "main": "src/scripts/g5-component.js",
+  "module": "src/scripts/g5-component.js",
   "browserify": {
     "transform": [
       "babelify",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "browserify": {
     "transform": [
       "babelify",
-      "aliasify",
       [
         "hbsfy",
         {
@@ -45,16 +44,6 @@
     ]
   },
   "browser": {
-    "model": "./src/scripts/model/master.js",
-    "viewModel": "./src/scripts/viewModel/master.js",
-    "eventTower": "./src/scripts/events/master.js",
-    "eventGroup": "./src/scripts/events/group/group.js",
-    "eventGroupExtender": "./src/scripts/events/group/extender.js",
-    "component": "./src/scripts/component/master.js",
-    "component-template": "./src/template/component.html",
-    "component-extender": "./src/scripts/component/extender.js",
-    "component-helpers": "./src/scripts/component/helpers.js",
-    "component-partials": "./src/scripts/component/partials.js"
   },
   "config": {
     "ghooks": {
@@ -67,10 +56,10 @@
     "start-dev": "npm run watch & npm run serve",
     "compress-images": "imagemin --progressive src/images/* src/images/build",
     "postcompress-images": "echo 'imagemin complete'",
-    "build-js": "browserify -u bootstrap -u jquery -u lodash -u isomorphic-fetch src/scripts/g5-component.js --s 'g5-component' | uglifyjs --mangle --compress drop_console,drop_debugger,dead_code,unused > dist/g5-component-bundle.js",
-    "build-js-dev": "browserify -u bootstrap -u jquery -u lodash -u isomorphic-fetch src/scripts/g5-component.js --s 'g5-component' > dist/g5-component-bundle.js",
+    "build-js": "browserify -u bootstrap -u jquery -u lodash -u isomorphic-fetch src/scripts/g5-component-browser.js --s 'g5-component' | uglifyjs --mangle --compress drop_console,drop_debugger,dead_code,unused > dist/g5-component-bundle.js",
+    "build-js-dev": "browserify -u bootstrap -u jquery -u lodash -u isomorphic-fetch src/scripts/g5-component-browser.js --s 'g5-component' > dist/g5-component-bundle.js",
     "build-js-vendor": "browserify -r bootstrap -r jquery -r lodash -r isomorphic-fetch | uglifyjs --enclose --mangle --compress drop_console,drop_debugger,dead_code,unused > dist/g5-component-vendor.js",
-    "build-js-full": "browserify src/scripts/g5-component.js --s 'g5-component' | uglifyjs --mangle --compress drop_console,drop_debugger,dead_code,unused > dist/g5-component.js",
+    "build-js-full": "browserify src/scripts/g5-component-browser.js --s 'g5-component' | uglifyjs --mangle --compress drop_console,drop_debugger,dead_code,unused > dist/g5-component.js",
     "build-js-all": "npm run build-js-vendor && npm run build-js && npm run build-js-full",
     "build-css": "lessc --include-path=node_modules/bootstrap/less:src/styles src/styles/component.less > dist/g5-component.css",
     "postbuild-css": "npm run minify-css && npm run gzip-css",
@@ -88,7 +77,6 @@
     "prelint": "echo 'Checking code via JSHint...'"
   },
   "dependencies": {
-    "aliasify": "^2.1.0",
     "babel-core": "^6.24.0",
     "babel-preset-es2015": "^6.24.0",
     "babelify": "^7.3.0",

--- a/src/scripts/component/extender.js
+++ b/src/scripts/component/extender.js
@@ -6,9 +6,7 @@
  *
  */
 
-'use strict';
-
-const pkg = require('./../../../package');
+import pkg from './../../../package.json';
 
 /**
  *
@@ -20,7 +18,7 @@ const pkg = require('./../../../package');
  */
 function getGameClasses(opts={}) {
 
-    let { component } = opts;
+    const { component } = opts;
 
     return `${component}__container ${component}__container--example`;
 
@@ -36,11 +34,11 @@ function getGameClasses(opts={}) {
  */
 function extender(data={}, opts={}) {
 
-    let { game, subject, copyright } = data;
-    let { component } = opts;
-    let { version } = pkg;
+    const { game, subject, copyright } = data;
+    const { component } = opts;
+    const { version } = pkg;
 
-    let css = getGameClasses(opts);
+    const css = getGameClasses(opts);
 
     return {
         css,
@@ -52,4 +50,4 @@ function extender(data={}, opts={}) {
 
 }
 
-module.exports = extender;
+export default extender;

--- a/src/scripts/component/helpers.js
+++ b/src/scripts/component/helpers.js
@@ -6,15 +6,13 @@
  *
  */
 
-'use strict';
-
 /**
  *
  * @name helpers
  * @description handlebars helpers to be registered
  *
  */
-let helpers = {
+const helpers = {
     /**
      *
      * @function ifOr
@@ -67,4 +65,4 @@ let helpers = {
     }
 };
 
-module.exports = helpers;
+export default helpers;

--- a/src/scripts/component/master.js
+++ b/src/scripts/component/master.js
@@ -7,15 +7,7 @@
  *
  */
 
-'use strict';
-
-const $ = global.jQuery = require('jquery');
-const utils = require('./../utils/master');
-const assign = require('lodash.assign');
-const create = require('lodash.create');
-const isFunction = require('lodash.isfunction');
-
-require('bootstrap/js/tooltip');
+import utils from './../utils/master';
 
 /**
  *
@@ -25,7 +17,7 @@ require('bootstrap/js/tooltip');
  * be emitted via the parent
  *
  */
-let component = {
+class Component {
     /**
      *
      * @method init
@@ -37,15 +29,15 @@ let component = {
      */
     init(data={}) {
 
-        let { opts } = this;
-        let { extendListeners } = opts;
+        const { opts } = this;
+        const { extendListeners } = opts;
 
         this.dataCache = data;
         this.render().addEvents(extendListeners);
 
         return this;
 
-    },
+    }
     /**
      *
      * @method render
@@ -57,11 +49,9 @@ let component = {
 
         utils.log('render component');
 
-        this.$element.find('[data-toggle="tooltip"]').tooltip();
-
         return this;
 
-    },
+    }
     /**
      *
      * @method addEvents
@@ -85,13 +75,13 @@ let component = {
 
         });
 
-        if (isFunction(cb)) {
+        if (cb instanceof Function) {
             cb(this.$element[0]);
         }
 
         return this;
 
-    },
+    }
     /**
      *
      * @method destroy
@@ -107,7 +97,7 @@ let component = {
         return this;
 
     }
-};
+}
 
 /**
  *
@@ -118,15 +108,17 @@ let component = {
  */
 function componentFactory(parent={}) {
 
-    let { opts, container, dataCache } = parent;
+    const { opts, element, container, dataCache } = parent;
 
-    return assign(create(component), {
-        $element: $(container),
-        parent,
-        dataCache,
-        opts
-    });
+    const component = new Component();
+
+    component.dataCache = dataCache;
+    component.element = element || container;
+    component.parent = parent;
+    component.opts = opts;
+
+    return component;
 
 }
 
-module.exports = componentFactory;
+export default componentFactory;

--- a/src/scripts/component/partials.js
+++ b/src/scripts/component/partials.js
@@ -6,7 +6,7 @@
  *
  */
 
-'use strict';
+import gameMedia from '../../template/partials/game-media.html';
 
 /**
  *
@@ -15,8 +15,8 @@
  * @note paths must be hardcoded because Browserify can only do static string analysis
  *
  */
-let partials = {
-    'game-media': require('../../template/partials/game-media.html')
+const partials = {
+    'game-media': gameMedia
 };
 
-module.exports = partials;
+export default partials;

--- a/src/scripts/dependencies/container.js
+++ b/src/scripts/dependencies/container.js
@@ -1,0 +1,40 @@
+/**
+ *
+ * @module g5-component-dependencies
+ * @desc a dependency injection container.
+ *
+ */
+
+export default {
+
+    // MasterViewModel
+
+    component: () => {
+        return {
+            destroy: () => {}
+        }
+    },
+
+    template: {},
+    helpers: {},
+    partials: {},
+    extender: {},
+
+
+    // G5Component
+
+    Model: class {},
+    ViewModel: class {},
+    EventTower: class {},
+
+
+    // EventTower
+
+    eventGroup: () => {
+        return {};
+    },
+    eventGroupExtender: () => {
+        return {};
+    }
+
+};

--- a/src/scripts/dependencies/container.js
+++ b/src/scripts/dependencies/container.js
@@ -1,7 +1,21 @@
 /**
  *
- * @module g5-component-dependencies
- * @desc a dependency injection container.
+ * @module g5-component-dependency-container
+ * @desc a dependency (injection) container.
+ *
+ * When the base G5Component initializes, it will use the implementations/dependencies
+ * assigned to this container.
+ *
+ * An extending or custom g5Component will implement most if not all of these elements.
+ * For the implementation interface needed for each of these dependencies, please (see) ...
+ *
+ * @see ./defaultInjector.js
+ *
+ * and the types that it injects. Your implementations may also elect to use those default types
+ * as base classes for extension.
+ *
+ * You can also inject other external dependencies here for general component-level use, such as
+ * moment, jQuery, etc.
  *
  */
 
@@ -11,6 +25,9 @@ export default {
 
     component: () => {
         return {
+            /** @method init */
+            /** @method addEvents */
+            /** @method render */
             destroy: () => {}
         }
     },

--- a/src/scripts/dependencies/defaultInjector.js
+++ b/src/scripts/dependencies/defaultInjector.js
@@ -1,0 +1,40 @@
+import component from './../component/master';
+import template from './../../template/component.html';
+import helpers from './../component/helpers';
+import partials from './../component/partials';
+import extender from './../component/extender';
+
+import Model from './../model/master';
+import ViewModel from './../viewModel/master';
+import EventTower from './../events/master';
+
+import eventGroup from './../events/group/group';
+import eventGroupExtender from './../events/group/extender';
+
+import container from './container';
+
+/**
+ *
+ * This is the default dependency arrangement of G5Component.
+ * You can provide overrides by assigning them into the dependency injection container,
+ * as demonstrated in this function.
+ *
+ * @module defaultInjector
+ *
+ */
+export default function () {
+
+    container.component = component;
+    container.template = template;
+    container.helpers = helpers;
+    container.partials = partials;
+    container.extender = extender;
+
+    container.Model = Model;
+    container.ViewModel = ViewModel;
+    container.EventTower = EventTower;
+
+    container.eventGroup = eventGroup;
+    container.eventGroupExtender = eventGroupExtender;
+
+};

--- a/src/scripts/dependencies/defaultInjector.js
+++ b/src/scripts/dependencies/defaultInjector.js
@@ -11,18 +11,19 @@ import EventTower from './../events/master';
 import eventGroup from './../events/group/group';
 import eventGroupExtender from './../events/group/extender';
 
-import container from './container';
-
 /**
  *
- * This is the default dependency arrangement of G5Component.
- * You can provide overrides by assigning them into the dependency injection container,
+ * This is the default dependency arrangement of G5Component used standalone.
+ *
+ * You can provide overrides by assigning them into the G5 dependency injection container,
  * as demonstrated in this function.
  *
- * @module defaultInjector
+ * These types are open for extension by your overrides.
+ *
+ * @param {object} container
  *
  */
-export default function () {
+export default function (container) {
 
     container.component = component;
     container.template = template;

--- a/src/scripts/events/group/extender.js
+++ b/src/scripts/events/group/extender.js
@@ -6,8 +6,6 @@
  *
  */
 
-'use strict';
-
 /**
  *
  * @function eventGroup
@@ -24,4 +22,4 @@ function eventGroup(master={}, model={}, viewModel={}) {
 
 }
 
-module.exports = eventGroup;
+export default eventGroup;

--- a/src/scripts/events/group/group.js
+++ b/src/scripts/events/group/group.js
@@ -6,8 +6,6 @@
  *
  */
 
-'use strict';
-
 /**
  *
  * @function eventGroup
@@ -127,4 +125,4 @@ function eventGroup(master={}, model={}, viewModel={}) {
 
 }
 
-module.exports = eventGroup;
+export default eventGroup;

--- a/src/scripts/g5-component-browser.js
+++ b/src/scripts/g5-component-browser.js
@@ -1,0 +1,9 @@
+import g5ComponentFactory from './g5-component';
+import defaultInjector from './dependencies/defaultInjector';
+
+defaultInjector();
+
+// use named export at the top level
+// @todo allow export default to generate name of bundle
+
+module.exports = g5ComponentFactory;

--- a/src/scripts/g5-component-browser.js
+++ b/src/scripts/g5-component-browser.js
@@ -1,7 +1,8 @@
 import g5ComponentFactory from './g5-component';
 import defaultInjector from './dependencies/defaultInjector';
+import container from './dependencies/container';
 
-defaultInjector();
+defaultInjector(container);
 
 // use named export at the top level
 // @todo allow export default to generate name of bundle

--- a/src/scripts/utils/master.js
+++ b/src/scripts/utils/master.js
@@ -6,14 +6,12 @@
  *
  */
 
-'use strict';
-
 /**
  *
  * @name utils
  *
  */
-let utils = {
+const utils = {
     months: [
         'Jan',
         'Feb',
@@ -36,12 +34,12 @@ let utils = {
      */
     log() {
 
-        let timestamp = utils.timestamp;
-        let args = Array.prototype.slice.call(arguments);
+        const timestamp = utils.timestamp;
+        const args = Array.prototype.slice.call(arguments);
 
-        args.unshift(timestamp() + ' - g5-component :');
+        args.unshift(`${timestamp()} - g5-component :`);
 
-        console.log.apply(console, args);
+        console.log(...args);
 
     },
     /**
@@ -53,7 +51,7 @@ let utils = {
      */
     pad(n) {
 
-        return n < 10 ? '0' + n.toString(10) : n.toString(10);
+        return n < 10 ? `0${n.toString(10)}` : n.toString(10);
 
     },
     /**
@@ -64,10 +62,10 @@ let utils = {
      */
     timestamp() {
 
-        let { pad, months } = utils;
-        let d = new Date();
+        const { pad, months } = utils;
+        const d = new Date();
 
-        let time = [
+        const time = [
             pad(d.getHours()),
             pad(d.getMinutes()),
             pad(d.getSeconds())
@@ -78,4 +76,4 @@ let utils = {
     }
 };
 
-module.exports = utils;
+export default utils;

--- a/test/events-master.js
+++ b/test/events-master.js
@@ -9,13 +9,13 @@
 'use strict';
 
 const test = require('tape');
-const EventTower = require('./../src/scripts/events/master');
+const EventTower = require('./../src/scripts/events/master').default;
 
 test('events-master test', (t) => {
 
     t.plan(3);
 
-    let eventTower = EventTower();
+    let eventTower = new EventTower();
 
     t.ok(eventTower instanceof EventTower, 'eventTower should have instance of EventTower');
 

--- a/test/g5-component.js
+++ b/test/g5-component.js
@@ -9,7 +9,7 @@
 'use strict';
 
 const test = require('tape');
-const g5Component = require('./../src/scripts/g5-component');
+const g5Component = require('./../src/scripts/g5-component').default;
 const EventEmitter = require('events').EventEmitter;
 
 test('g5-component core test', (t) => {
@@ -23,7 +23,7 @@ test('g5-component core test', (t) => {
         path: '/src/data/linescore.json'
     });
 
-    t.ok(linescoreComponent instanceof EventEmitter, 'g5Component should have instance of EventeEmitter');
+    t.ok(linescoreComponent instanceof EventEmitter, 'g5Component should have instance of EventEmitter');
 
     t.test('g5Component should have expected properties', (st) => {
 

--- a/test/model-master.js
+++ b/test/model-master.js
@@ -9,14 +9,14 @@
 'use strict';
 
 const test = require('tape');
-const MasterModel = require('./../src/scripts/model/master');
+const MasterModel = require('./../src/scripts/model/master').default;
 const EventEmitter = require('events').EventEmitter;
 
 test('model-master test', (t) => {
 
     t.plan(7);
 
-    let model = MasterModel({
+    let model = new MasterModel({
         path: '/src/data/linescore.json'
     });
 

--- a/test/viewModel-master.js
+++ b/test/viewModel-master.js
@@ -9,14 +9,14 @@
 'use strict';
 
 const test = require('tape');
-const MasterViewModel = require('./../src/scripts/viewModel/master');
+const MasterViewModel = require('./../src/scripts/viewModel/master').default;
 const EventEmitter = require('events').EventEmitter;
 
 test('viewModel-master test', (t) => {
 
     t.plan(6);
 
-    let viewModel = MasterViewModel();
+    let viewModel = new MasterViewModel();
 
     viewModel.container = {};
     viewModel.component.destroy = () => {};


### PR DESCRIPTION
A step towards a few items in https://github.com/MajorLeagueBaseball/g5-component/issues/18

- ESM syntax replaces 'require' statements
- explicit dependency injection instead of using aliases
- G5Component exportable as class (with no default dependencies)

Tested npm run build and example server verified amd/global and split builds. Under node 6.9.5.

We should discuss this, since I don't think I can fully explain this with a PR note.