### PR TITLE
fix/event binding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "g5-component",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Browserify Component Scaffold",
   "author": "Greg Babula <greg.babula@mlb.com>",
   "contributors": [
@@ -27,7 +27,14 @@
   "module": "src/scripts/g5-component.js",
   "browserify": {
     "transform": [
-      ["babelify", { "presets": ["es2015"] }],
+      [
+        "babelify",
+        {
+          "presets": [
+            "es2015"
+          ]
+        }
+      ],
       [
         "hbsfy",
         {
@@ -67,7 +74,6 @@
     "lint": "jshint src/scripts/ || true",
     "disk-usage": "du -sh ./dist/*",
     "prelint": "echo 'Checking code via JSHint...'",
-
     "build-js-composition-example": "browserify example/src/composition/g5-component-composition.js --s 'g5-component' > example/dist/g5-component-composition.js",
     "build-js-simple-example": "browserify example/src/simple/g5-component-simple.js --s 'g5-component' > example/dist/g5-component-simple.js",
     "build-examples": "npm run build-js-composition-example; npm run build-js-simple-example; du -sh ./example/dist/*",
@@ -97,6 +103,5 @@
     "uglify-js": "^2.8.14",
     "xmlhttprequest": "^1.8.0"
   },
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }

--- a/src/scripts/dependencies/container.js
+++ b/src/scripts/dependencies/container.js
@@ -29,7 +29,7 @@ export function stub() {
             return {
                 init: () => {},
                 destroy: () => {}
-            }
+            };
         },
         template: {},
         helpers: {},

--- a/src/scripts/utils/master.js
+++ b/src/scripts/utils/master.js
@@ -16,7 +16,7 @@ export function Log() {
     this.store = [];
 
     const fn = function (...args) {
-        utils.log(this, ...args)
+        utils.log(this, ...args);
     }.bind(this);
 
     fn.store = this.store;

--- a/src/scripts/viewModel/master.js
+++ b/src/scripts/viewModel/master.js
@@ -208,6 +208,8 @@ class MasterViewModel extends EventEmitter {
                 this.container.innerHTML = template;
             }
 
+            this.bound = false;
+
         }
 
         if (!this.bound) {
@@ -289,7 +291,7 @@ class MasterViewModel extends EventEmitter {
         this.partials = null;
         this.extender = null;
 
-        this.container.outerHTML = '';
+        this.container.innerHTML = '';
         this.container = null;
 
         return this;


### PR DESCRIPTION
\+ @staxmanade 

_Rest o'y'all's public github handles ain't comin' to mind presently..._

- if the `ViewModel` rewrites its contents with `bindComponent()`, consider itself unbound and call component.init again, with the intent of rebinding any events that were discarded with the old html.
- `void destroy()` modified to only remove innerHTML, reasoning that the container was there before the component existed, and is within the responsibility of the parent page. Destroy is rarely called in practice.

This has already been published as a patch internally (3.0.1).